### PR TITLE
Event Key Safety

### DIFF
--- a/example/foo_test.go
+++ b/example/foo_test.go
@@ -19,11 +19,20 @@ import (
 	"github.com/pentops/protostate/psm"
 	"github.com/pentops/protostate/testproto/gen/testpb"
 	"github.com/pentops/sqrlx.go/sqrlx"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"k8s.io/utils/ptr"
 )
+
+func TestStateEntityExtensions(t *testing.T) {
+	event := &testpb.FooEvent{}
+	assert.Equal(t, testpb.FooPSMEventNil, event.PSMEventKey())
+	event.SetPSMEvent(&testpb.FooEventType_Created{})
+	assert.Equal(t, testpb.FooPSMEventCreated, event.Event.PSMEventKey())
+	assert.Equal(t, testpb.FooPSMEventCreated, event.PSMEventKey())
+}
 
 func NewFooStateMachine(db *sqrlx.Wrapper) (*testpb.FooPSM, error) {
 	customTableSpec := testpb.DefaultFooPSMTableSpec

--- a/testproto/gen/testpb/bar_psm.pb.go
+++ b/testproto/gen/testpb/bar_psm.pb.go
@@ -90,6 +90,7 @@ func BarPSMFunc[SE BarPSMEvent](cb func(context.Context, BarPSMTransitionBaton, 
 type BarPSMEventKey string
 
 const (
+	BarPSMEventNil     BarPSMEventKey = "<nil>"
 	BarPSMEventCreated BarPSMEventKey = "created"
 	BarPSMEventUpdated BarPSMEventKey = "updated"
 	BarPSMEventDeleted BarPSMEventKey = "deleted"
@@ -126,6 +127,9 @@ func (c BarPSMConverter) CheckStateKeys(s *BarState, e *BarEvent) error {
 }
 
 func (ee *BarEventType) UnwrapPSMEvent() BarPSMEvent {
+	if ee == nil {
+		return nil
+	}
 	switch v := ee.Type.(type) {
 	case *BarEventType_Created_:
 		return v.Created
@@ -140,14 +144,20 @@ func (ee *BarEventType) UnwrapPSMEvent() BarPSMEvent {
 func (ee *BarEventType) PSMEventKey() BarPSMEventKey {
 	tt := ee.UnwrapPSMEvent()
 	if tt == nil {
-		return "<nil>"
+		return BarPSMEventNil
 	}
 	return tt.PSMEventKey()
+}
+func (ee *BarEvent) PSMEventKey() BarPSMEventKey {
+	return ee.Event.PSMEventKey()
 }
 func (ee *BarEvent) UnwrapPSMEvent() BarPSMEvent {
 	return ee.Event.UnwrapPSMEvent()
 }
 func (ee *BarEvent) SetPSMEvent(inner BarPSMEvent) {
+	if ee.Event == nil {
+		ee.Event = &BarEventType{}
+	}
 	switch v := inner.(type) {
 	case *BarEventType_Created:
 		ee.Event.Type = &BarEventType_Created_{Created: v}

--- a/testproto/gen/testpb/foo_psm.pb.go
+++ b/testproto/gen/testpb/foo_psm.pb.go
@@ -92,6 +92,7 @@ func FooPSMFunc[SE FooPSMEvent](cb func(context.Context, FooPSMTransitionBaton, 
 type FooPSMEventKey string
 
 const (
+	FooPSMEventNil     FooPSMEventKey = "<nil>"
 	FooPSMEventCreated FooPSMEventKey = "created"
 	FooPSMEventUpdated FooPSMEventKey = "updated"
 	FooPSMEventDeleted FooPSMEventKey = "deleted"
@@ -138,6 +139,9 @@ func (c FooPSMConverter) CheckStateKeys(s *FooState, e *FooEvent) error {
 }
 
 func (ee *FooEventType) UnwrapPSMEvent() FooPSMEvent {
+	if ee == nil {
+		return nil
+	}
 	switch v := ee.Type.(type) {
 	case *FooEventType_Created_:
 		return v.Created
@@ -152,14 +156,20 @@ func (ee *FooEventType) UnwrapPSMEvent() FooPSMEvent {
 func (ee *FooEventType) PSMEventKey() FooPSMEventKey {
 	tt := ee.UnwrapPSMEvent()
 	if tt == nil {
-		return "<nil>"
+		return FooPSMEventNil
 	}
 	return tt.PSMEventKey()
+}
+func (ee *FooEvent) PSMEventKey() FooPSMEventKey {
+	return ee.Event.PSMEventKey()
 }
 func (ee *FooEvent) UnwrapPSMEvent() FooPSMEvent {
 	return ee.Event.UnwrapPSMEvent()
 }
 func (ee *FooEvent) SetPSMEvent(inner FooPSMEvent) {
+	if ee.Event == nil {
+		ee.Event = &FooEventType{}
+	}
 	switch v := inner.(type) {
 	case *FooEventType_Created:
 		ee.Event.Type = &FooEventType_Created_{Created: v}


### PR DESCRIPTION
- Primary Key Fields in TableSpec
- erg...
- List Filter at Request Object
- Bool Filter
- fix collapsing and organize tests
- Nested Field Sort Fix
- start honoring the page size in the request
- give an error if the requested page size exceeds the maximum allowed size
- External Prototest
- Validate PSM Query before trying PSM fallback
- More friendly errors for issues
- add optional description field to foo
- update old tests
- add test showing state marshals in and out like expected
- emit default values
- use same marshal for event and state json
- add failing test
- and use the new way to make the test pass
- more complex sortable field in foo
- build dynamic sorts
- dynamic sort tests
- print query helper to delete later
- fixup tests and add second list of multisort
- drop has check
- add note about get vs has
- more notes
- drop print command now that we're done debugging
- map in use of the tenant id so it's not just null
- add test for listing by tenant id and not by tenant id
- don't add in an empty where
- Protections and wrappers for PSM Event Keys
