### PR TITLE
fix event keys

### DIFF
--- a/cmd/protoc-gen-go-psm/main.go
+++ b/cmd/protoc-gen-go-psm/main.go
@@ -654,6 +654,20 @@ func addDefaultTableSpec(g *protogen.GeneratedFile, ss *stateSet) error {
 	}
 	g.P("    }, nil")
 	g.P("  },")
+	g.P("  StateColumns: func(state *", ss.stateMessage.GoIdent, ") (map[string]interface{}, error) {")
+	g.P("    return map[string]interface{}{")
+
+	for _, field := range ss.eventFieldGenerators.eventStateKeyFields {
+		if field.isKey {
+			continue
+		}
+		// stripping the prefix foo_ from the name in the event. In the DB, we
+		// expect the primary key to be called just id, so foo_id -> id
+		keyName := strings.TrimPrefix(string(field.stateField.Desc.Name()), ss.specifiedName+"_")
+		g.P("      \"", keyName, "\": state.", field.eventField.GoName, ",")
+	}
+	g.P("    }, nil")
+	g.P("  },")
 
 	g.P("  EventColumns: func(event *", ss.eventMessage.GoIdent, ") (map[string]interface{}, error) {")
 	g.P("    metadata := event.", ss.metadataField.GoName)

--- a/example/bar_test.go
+++ b/example/bar_test.go
@@ -16,8 +16,8 @@ import (
 func NewBarStateMachine(db *sqrlx.Wrapper) (*testpb.BarPSM, error) {
 
 	sm, err := testpb.NewBarPSM(db, psm.WithTableSpec(testpb.BarPSMTableSpec{
-		StateTable: "foo",
-		EventTable: "foo_event",
+		StateTable: "bar",
+		EventTable: "bar_event",
 		PrimaryKey: func(event *testpb.BarEvent) (map[string]interface{}, error) {
 			return map[string]interface{}{
 				"id": event.BarId,
@@ -25,7 +25,7 @@ func NewBarStateMachine(db *sqrlx.Wrapper) (*testpb.BarPSM, error) {
 		},
 		EventColumns: func(event *testpb.BarEvent) (map[string]interface{}, error) {
 			return map[string]interface{}{
-				"foo_id":    event.BarId,
+				"bar_id":    event.BarId,
 				"id":        event.Metadata.EventId,
 				"timestamp": event.Metadata.Timestamp,
 				"data":      event,

--- a/example/foo_test.go
+++ b/example/foo_test.go
@@ -36,11 +36,6 @@ func TestStateEntityExtensions(t *testing.T) {
 
 func NewFooStateMachine(db *sqrlx.Wrapper) (*testpb.FooPSM, error) {
 	customTableSpec := testpb.DefaultFooPSMTableSpec
-	customTableSpec.ExtraStateColumns = func(state *testpb.FooState) (map[string]interface{}, error) {
-		return map[string]interface{}{
-			"tenant_id": state.TenantId,
-		}, nil
-	}
 
 	sm, err := testpb.NewFooPSM(db, psm.WithTableSpec(customTableSpec))
 	if err != nil {

--- a/testproto/db/20231120150807_init.sql
+++ b/testproto/db/20231120150807_init.sql
@@ -2,7 +2,7 @@
 
 CREATE TABLE foo (
 	id uuid primary key,
-	state jsonb,
+	state jsonb NOT NULL,
 	tenant_id uuid
 );
 
@@ -11,8 +11,20 @@ CREATE TABLE foo_event (
 	timestamp timestamptz NOT NULL,
 	foo_id uuid references foo(id) NOT NULL,
 	tenant_id uuid,
-	actor jsonb,
-	data jsonb
+	actor jsonb NOT NULL,
+	data jsonb NOT NULL
+);
+
+CREATE TABLE bar (
+	id uuid primary key,
+	state jsonb NOT NULL
+);
+
+CREATE TABLE bar_event (
+	id uuid primary key,
+	timestamp timestamptz NOT NULL,
+	bar_id uuid references bar(id) NOT NULL,
+	data jsonb NOT NULL
 );
 
 -- +goose Down

--- a/testproto/gen/testpb/bar_psm.pb.go
+++ b/testproto/gen/testpb/bar_psm.pb.go
@@ -53,6 +53,9 @@ var DefaultBarPSMTableSpec = BarPSMTableSpec{
 			"id": event.BarId,
 		}, nil
 	},
+	StateColumns: func(state *BarState) (map[string]interface{}, error) {
+		return map[string]interface{}{}, nil
+	},
 	EventColumns: func(event *BarEvent) (map[string]interface{}, error) {
 		metadata := event.Metadata
 		return map[string]interface{}{

--- a/testproto/gen/testpb/foo_psm.pb.go
+++ b/testproto/gen/testpb/foo_psm.pb.go
@@ -53,6 +53,11 @@ var DefaultFooPSMTableSpec = FooPSMTableSpec{
 			"id": event.FooId,
 		}, nil
 	},
+	StateColumns: func(state *FooState) (map[string]interface{}, error) {
+		return map[string]interface{}{
+			"tenant_id": state.TenantId,
+		}, nil
+	},
 	EventColumns: func(event *FooEvent) (map[string]interface{}, error) {
 		metadata := event.Metadata
 		return map[string]interface{}{


### PR DESCRIPTION
- Primary Key Fields in TableSpec
- erg...
- List Filter at Request Object
- Bool Filter
- fix collapsing and organize tests
- Nested Field Sort Fix
- start honoring the page size in the request
- give an error if the requested page size exceeds the maximum allowed size
- External Prototest
- Validate PSM Query before trying PSM fallback
- More friendly errors for issues
- add optional description field to foo
- update old tests
- add test showing state marshals in and out like expected
- emit default values
- use same marshal for event and state json
- add failing test
- and use the new way to make the test pass
- more complex sortable field in foo
- build dynamic sorts
- dynamic sort tests
- print query helper to delete later
- fixup tests and add second list of multisort
- drop has check
- add note about get vs has
- more notes
- drop print command now that we're done debugging
- map in use of the tenant id so it's not just null
- add test for listing by tenant id and not by tenant id
- don't add in an empty where
- Protections and wrappers for PSM Event Keys
- Auto-map state keys from event
