### PR TITLE
No DB by default

### DIFF
--- a/cmd/protoc-gen-go-psm/main.go
+++ b/cmd/protoc-gen-go-psm/main.go
@@ -497,7 +497,10 @@ func addStateSet(g *protogen.GeneratedFile, ss *stateSet) error {
 	g.P("type ", ss.machineName, " = ", sm.Ident("StateMachine"), "[")
 	printTypes()
 	g.P("]")
-
+	g.P()
+	g.P("type ", ss.machineName, "DB = ", sm.Ident("DBStateMachine"), "[")
+	printTypes()
+	g.P("]")
 	g.P()
 
 	FooPSM := ss.machineName
@@ -516,12 +519,12 @@ func addStateSet(g *protogen.GeneratedFile, ss *stateSet) error {
 	g.P()
 
 	// func NewFooPSM(db psm.Transactor, options ...FooPSMOption) (*FooPSM, error) {
-	g.P("func New", ss.machineName, "(db ", sm.Ident("Transactor"), ", config *", sm.Ident("StateMachineConfig"), "[")
+	g.P("func New", ss.machineName, "(config *", sm.Ident("StateMachineConfig"), "[")
 	printTypes()
 	g.P("]) (*", FooPSM, ", error) {")
 	g.P("return ", sm.Ident("NewStateMachine"), "[")
 	printTypes()
-	g.P("](db, config)")
+	g.P("](config)")
 	g.P("}")
 	g.P()
 

--- a/example/bar_test.go
+++ b/example/bar_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func NewBarStateMachine(db *sqrlx.Wrapper) (*testpb.BarPSM, error) {
+func NewBarStateMachine(db *sqrlx.Wrapper) (*testpb.BarPSMDB, error) {
 
 	config := testpb.DefaultBarPSMConfig().
 		WithTableSpec(testpb.BarPSMTableSpec{
@@ -33,7 +33,7 @@ func NewBarStateMachine(db *sqrlx.Wrapper) (*testpb.BarPSM, error) {
 			},
 		})
 
-	sm, err := testpb.NewBarPSM(db, config)
+	sm, err := testpb.NewBarPSM(config)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func NewBarStateMachine(db *sqrlx.Wrapper) (*testpb.BarPSM, error) {
 			return nil
 		}))
 
-	return (*testpb.BarPSM)(sm), nil
+	return (*testpb.BarPSMDB)(sm.WithDB(db)), nil
 }
 
 func TestBarStateMachine(t *testing.T) {

--- a/example/foo_test.go
+++ b/example/foo_test.go
@@ -36,7 +36,7 @@ func TestStateEntityExtensions(t *testing.T) {
 
 var fooActorID = uuid.NewString()
 
-func NewFooStateMachine(db *sqrlx.Wrapper) (*testpb.FooPSM, error) {
+func NewFooStateMachine(db *sqrlx.Wrapper) (*testpb.FooPSMDB, error) {
 	customTableSpec := testpb.DefaultFooPSMTableSpec
 
 	systemActor, err := psm.NewSystemActor(fooActorID, &testpb.Actor{
@@ -45,7 +45,7 @@ func NewFooStateMachine(db *sqrlx.Wrapper) (*testpb.FooPSM, error) {
 	if err != nil {
 		return nil, err
 	}
-	sm, err := testpb.NewFooPSM(db, testpb.
+	sm, err := testpb.NewFooPSM(testpb.
 		DefaultFooPSMConfig().
 		WithTableSpec(customTableSpec).
 		WithSystemActor(systemActor))
@@ -109,7 +109,7 @@ func NewFooStateMachine(db *sqrlx.Wrapper) (*testpb.FooPSM, error) {
 			return nil
 		}))
 
-	return (*testpb.FooPSM)(sm), nil
+	return (*testpb.FooPSMDB)(sm.WithDB(db)), nil
 }
 
 func TestFooStateMachine(t *testing.T) {

--- a/testproto/gen/testpb/bar_psm.pb.go
+++ b/testproto/gen/testpb/bar_psm.pb.go
@@ -25,6 +25,13 @@ type BarPSM = psm.StateMachine[
 	BarPSMEvent,
 ]
 
+type BarPSMDB = psm.DBStateMachine[
+	*BarState,
+	BarStatus,
+	*BarEvent,
+	BarPSMEvent,
+]
+
 func DefaultBarPSMConfig() *psm.StateMachineConfig[
 	*BarState,
 	BarStatus,
@@ -39,7 +46,7 @@ func DefaultBarPSMConfig() *psm.StateMachineConfig[
 	](BarPSMConverter{}, DefaultBarPSMTableSpec)
 }
 
-func NewBarPSM(db psm.Transactor, config *psm.StateMachineConfig[
+func NewBarPSM(config *psm.StateMachineConfig[
 	*BarState,
 	BarStatus,
 	*BarEvent,
@@ -50,7 +57,7 @@ func NewBarPSM(db psm.Transactor, config *psm.StateMachineConfig[
 		BarStatus,
 		*BarEvent,
 		BarPSMEvent,
-	](db, config)
+	](config)
 }
 
 type BarPSMTableSpec = psm.TableSpec[

--- a/testproto/gen/testpb/foo_psm.pb.go
+++ b/testproto/gen/testpb/foo_psm.pb.go
@@ -25,6 +25,13 @@ type FooPSM = psm.StateMachine[
 	FooPSMEvent,
 ]
 
+type FooPSMDB = psm.DBStateMachine[
+	*FooState,
+	FooStatus,
+	*FooEvent,
+	FooPSMEvent,
+]
+
 func DefaultFooPSMConfig() *psm.StateMachineConfig[
 	*FooState,
 	FooStatus,
@@ -39,7 +46,7 @@ func DefaultFooPSMConfig() *psm.StateMachineConfig[
 	](FooPSMConverter{}, DefaultFooPSMTableSpec)
 }
 
-func NewFooPSM(db psm.Transactor, config *psm.StateMachineConfig[
+func NewFooPSM(config *psm.StateMachineConfig[
 	*FooState,
 	FooStatus,
 	*FooEvent,
@@ -50,7 +57,7 @@ func NewFooPSM(db psm.Transactor, config *psm.StateMachineConfig[
 		FooStatus,
 		*FooEvent,
 		FooPSMEvent,
-	](db, config)
+	](config)
 }
 
 type FooPSMTableSpec = psm.TableSpec[


### PR DESCRIPTION
- Primary Key Fields in TableSpec
- erg...
- List Filter at Request Object
- Bool Filter
- fix collapsing and organize tests
- Nested Field Sort Fix
- start honoring the page size in the request
- give an error if the requested page size exceeds the maximum allowed size
- External Prototest
- Validate PSM Query before trying PSM fallback
- More friendly errors for issues
- add optional description field to foo
- update old tests
- add test showing state marshals in and out like expected
- emit default values
- use same marshal for event and state json
- add failing test
- and use the new way to make the test pass
- more complex sortable field in foo
- build dynamic sorts
- dynamic sort tests
- print query helper to delete later
- fixup tests and add second list of multisort
- drop has check
- add note about get vs has
- more notes
- drop print command now that we're done debugging
- map in use of the tenant id so it's not just null
- add test for listing by tenant id and not by tenant id
- don't add in an empty where
- Protections and wrappers for PSM Event Keys
- Auto-map state keys from event
- services shouldn't be knowing about storing as arrays
- Chain derived actor
- List Filter and List Events Filter are completely independent
- Remove DB from default PSM
