### PR TITLE
Unexpose

### DIFF
--- a/pquery/getter.go
+++ b/pquery/getter.go
@@ -190,7 +190,7 @@ func NewGetter[
 func (gc *Getter[REQ, RES]) Get(ctx context.Context, db Transactor, reqMsg REQ, resMsg RES) error {
 
 	as := newAliasSet()
-	rootAlias := as.Next()
+	rootAlias := as.Next(gc.tableName)
 
 	resReflect := resMsg.ProtoReflect()
 
@@ -226,7 +226,7 @@ func (gc *Getter[REQ, RES]) Get(ctx context.Context, db Transactor, reqMsg REQ, 
 
 		authAlias := rootAlias
 		if gc.authJoin != nil {
-			authAlias = as.Next()
+			authAlias = as.Next(gc.authJoin.TableName)
 			// LEFT JOIN
 			//   <t> AS authAlias
 			//   ON authAlias.<authJoin.foreignKeyColumn> = rootAlias.<authJoin.primaryKeyColumn>
@@ -246,7 +246,7 @@ func (gc *Getter[REQ, RES]) Get(ctx context.Context, db Transactor, reqMsg REQ, 
 	}
 
 	if gc.join != nil {
-		joinAlias := as.Next()
+		joinAlias := as.Next(gc.join.tableName)
 
 		selectQuery.
 			Column(fmt.Sprintf("ARRAY_AGG(%s.%s)", joinAlias, gc.join.dataColunn)).

--- a/pquery/lister.go
+++ b/pquery/lister.go
@@ -458,7 +458,7 @@ func (ll *Lister[REQ, RES]) List(ctx context.Context, db Transactor, reqMsg prot
 
 func (ll *Lister[REQ, RES]) BuildQuery(ctx context.Context, req protoreflect.Message, res protoreflect.Message) (*sqrl.SelectBuilder, error) {
 	as := newAliasSet()
-	tableAlias := as.Next()
+	tableAlias := as.Next(ll.tableName)
 
 	selectQuery := sq.
 		Select(fmt.Sprintf("%s.%s", tableAlias, ll.dataColumn)).
@@ -512,7 +512,7 @@ func (ll *Lister[REQ, RES]) BuildQuery(ctx context.Context, req protoreflect.Mes
 
 		for _, join := range ll.authJoin {
 			priorAlias := authAlias
-			authAlias = as.Next()
+			authAlias = as.Next(join.TableName)
 			selectQuery = selectQuery.LeftJoin(fmt.Sprintf(
 				"%s AS %s ON %s",
 				join.TableName,

--- a/pquery/query.go
+++ b/pquery/query.go
@@ -11,9 +11,9 @@ import (
 
 type aliasSet int
 
-func (as *aliasSet) Next() string {
+func (as *aliasSet) Next(name string) string {
 	*as++
-	return fmt.Sprintf("_gc_alias_%d", *as)
+	return fmt.Sprintf("_%s__a%d", name, *as)
 }
 
 func newAliasSet() *aliasSet {


### PR DESCRIPTION
- Primary Key Fields in TableSpec
- erg...
- List Filter at Request Object
- Bool Filter
- fix collapsing and organize tests
- Nested Field Sort Fix
- start honoring the page size in the request
- give an error if the requested page size exceeds the maximum allowed size
- External Prototest
- Validate PSM Query before trying PSM fallback
- More friendly errors for issues
- add optional description field to foo
- update old tests
- add test showing state marshals in and out like expected
- emit default values
- use same marshal for event and state json
- add failing test
- and use the new way to make the test pass
- more complex sortable field in foo
- build dynamic sorts
- dynamic sort tests
- print query helper to delete later
- fixup tests and add second list of multisort
- drop has check
- add note about get vs has
- more notes
- drop print command now that we're done debugging
- map in use of the tenant id so it's not just null
- add test for listing by tenant id and not by tenant id
- don't add in an empty where
- Protections and wrappers for PSM Event Keys
- Auto-map state keys from event
- services shouldn't be knowing about storing as arrays
- Chain derived actor
- List Filter and List Events Filter are completely independent
- Remove DB from default PSM
- Easier to read aliases
- Unexpose internal fields
