### PR TITLE
error helpers

### DIFF
--- a/cmd/protoc-gen-go-psm/main.go
+++ b/cmd/protoc-gen-go-psm/main.go
@@ -269,10 +269,6 @@ type eventFieldDescriptors struct {
 
 func (desc eventFieldDescriptors) validate() error {
 
-	if desc.metadataField == nil {
-		return fmt.Errorf("event object missing metadata field")
-	}
-
 	if desc.eventIDField == nil {
 		return fmt.Errorf("event object missing id field")
 	}
@@ -393,6 +389,10 @@ func buildEventFieldDescriptors(src stateEntityDescriptorSet) (*eventFieldDescri
 
 		}
 
+	}
+
+	if out.metadataField == nil {
+		return nil, fmt.Errorf("event object '%s' missing metadata field", src.eventOptions.Name)
 	}
 
 	metadataFields := out.metadataField.Message().Fields()

--- a/pquery/lister.go
+++ b/pquery/lister.go
@@ -353,6 +353,8 @@ func buildDefaultSorts(messageFields protoreflect.FieldDescriptors) []sortSpec {
 				})
 			}
 		} else if field.Kind() == protoreflect.MessageKind {
+			log.WithField(context.Background(), "message", field.Message().FullName()).Debug("buildDefaultSorts")
+
 			subSort := buildDefaultSorts(field.Message().Fields())
 			for idx, subSortField := range subSort {
 				subSortField.jsonPath = append([]string{field.JSONName()}, subSortField.jsonPath...)


### PR DESCRIPTION
- Primary Key Fields in TableSpec
- erg...
- List Filter at Request Object
- Bool Filter
- fix collapsing and organize tests
- Nested Field Sort Fix
- start honoring the page size in the request
- give an error if the requested page size exceeds the maximum allowed size
- External Prototest
- Validate PSM Query before trying PSM fallback
- More friendly errors for issues
- add optional description field to foo
- update old tests
- add test showing state marshals in and out like expected
- emit default values
- use same marshal for event and state json
- add failing test
- and use the new way to make the test pass
- more complex sortable field in foo
- build dynamic sorts
- dynamic sort tests
- print query helper to delete later
- fixup tests and add second list of multisort
- drop has check
- add note about get vs has
- more notes
- drop print command now that we're done debugging
- map in use of the tenant id so it's not just null
- add test for listing by tenant id and not by tenant id
- don't add in an empty where
- Protections and wrappers for PSM Event Keys
- Auto-map state keys from event
- services shouldn't be knowing about storing as arrays
- Chain derived actor
- List Filter and List Events Filter are completely independent
- Remove DB from default PSM
- Easier to read aliases
- Unexpose internal fields
- linting
- doesn't need a longer name
- regen
- split helpers off
- wip
- move event creation to helper constructors
- return a proper error
- Event Columns Wrapper
- create a failing test
- convert camel case to snake case for finding the field
- rearrange the tests so we're focussed on features not which set it goes to
- rename example to integration
- consolidate sorting test setup
- DB Sugar
- consistent field names
- Update gitignore for protoc-gen-go-psm
- Allow versions to be set and make a quicker builder script for plugin.
- Improve error message
- Error for no metadata, and log default sorts for recursion issue
