### PR TITLE
Constructor and Config Refactor

### DIFF
--- a/cmd/protoc-gen-go-psm/main.go
+++ b/cmd/protoc-gen-go-psm/main.go
@@ -528,7 +528,7 @@ func addStateSet(g *protogen.GeneratedFile, ss *stateSet) error {
 	g.P("}")
 	g.P()
 
-	g.P("type ", FooPSMTableSpec, " = ", sm.Ident("TableSpec"), "[")
+	g.P("type ", FooPSMTableSpec, " = ", sm.Ident("PSMTableSpec"), "[")
 	printTypes()
 	g.P("]")
 	g.P()

--- a/cmd/protoc-gen-go-psm/query_code.go
+++ b/cmd/protoc-gen-go-psm/query_code.go
@@ -72,11 +72,11 @@ func (qs PSMQuerySet) Write(g *protogen.GeneratedFile) error {
 	g.P()
 	qs.genericTypeAlias(g, qs.GoServiceName+"PSMQuerySpec", "QuerySpec")
 	g.P()
-	g.P("func Default", qs.GoServiceName, "PSMQuerySpec(tableSpec ", stateMachinePackage.Ident("StateTableSpec"), ") ", qs.GoServiceName, "PSMQuerySpec {")
+	g.P("func Default", qs.GoServiceName, "PSMQuerySpec(tableSpec ", stateMachinePackage.Ident("QueryTableSpec"), ") ", qs.GoServiceName, "PSMQuerySpec {")
 	g.P("  return ", stateMachinePackage.Ident("QuerySpec"), "[")
 	qs.writeGenericTypeSet(g)
 	g.P("  ]{")
-	g.P("    StateTableSpec: tableSpec,")
+	g.P("    QueryTableSpec: tableSpec,")
 	qs.listFilter(g, qs.ListREQ, "ListRequestFilter", qs.ListRequestFilter)
 	if qs.ListEventsREQ != nil {
 		qs.listFilter(g, *qs.ListEventsREQ, "ListEventsRequestFilter", qs.ListEventsRequestFilter)

--- a/psm/builder.go
+++ b/psm/builder.go
@@ -1,0 +1,68 @@
+package psm
+
+// StateMachineConfig allows the generated code to build a default
+// machine, but expose options to the user to override the defaults
+type StateMachineConfig[
+	S IState[ST],
+	ST IStatusEnum,
+	E IEvent[IE],
+	IE IInnerEvent,
+] struct {
+	conversions EventTypeConverter[S, ST, E, IE]
+	spec        PSMTableSpec[S, ST, E, IE]
+	systemActor *SystemActor
+}
+
+func NewStateMachineConfig[
+	S IState[ST],
+	ST IStatusEnum,
+	E IEvent[IE],
+	IE IInnerEvent,
+](
+	defaultConversions EventTypeConverter[S, ST, E, IE],
+	defaultSpec PSMTableSpec[S, ST, E, IE],
+) *StateMachineConfig[S, ST, E, IE] {
+	return &StateMachineConfig[S, ST, E, IE]{
+		conversions: defaultConversions,
+		spec:        defaultSpec,
+	}
+}
+
+func (cb *StateMachineConfig[S, ST, E, IE]) EventTypeConverter(conversions EventTypeConverter[S, ST, E, IE]) *StateMachineConfig[S, ST, E, IE] {
+	cb.conversions = conversions
+	return cb
+}
+
+func (cb *StateMachineConfig[S, ST, E, IE]) SystemActor(systemActor SystemActor) *StateMachineConfig[S, ST, E, IE] {
+	cb.systemActor = &systemActor
+	return cb
+}
+
+func (cb *StateMachineConfig[S, ST, E, IE]) StateTableName(stateTable string) *StateMachineConfig[S, ST, E, IE] {
+	cb.spec.State.TableName = stateTable
+	return cb
+}
+
+func (cb *StateMachineConfig[S, ST, E, IE]) StoreExtraStateColumns(stateColumns func(S) (map[string]interface{}, error)) *StateMachineConfig[S, ST, E, IE] {
+	cb.spec.State.StoreExtraColumns = stateColumns
+	return cb
+}
+
+func (cb *StateMachineConfig[S, ST, E, IE]) EventTableName(eventTable string) *StateMachineConfig[S, ST, E, IE] {
+	cb.spec.Event.TableName = eventTable
+	return cb
+}
+
+func (cb *StateMachineConfig[S, ST, E, IE]) StoreExtraEventColumns(eventColumns func(E) (map[string]interface{}, error)) *StateMachineConfig[S, ST, E, IE] {
+	cb.spec.Event.StoreExtraColumns = eventColumns
+	return cb
+}
+
+func (cb *StateMachineConfig[S, ST, E, IE]) PrimaryKey(primaryKey func(E) (map[string]interface{}, error)) *StateMachineConfig[S, ST, E, IE] {
+	cb.spec.PrimaryKey = primaryKey
+	return cb
+}
+
+func (cb *StateMachineConfig[S, ST, E, IE]) NewStateMachine() (*StateMachine[S, ST, E, IE], error) {
+	return NewStateMachine[S, ST, E, IE](cb)
+}

--- a/psm/state_query.go
+++ b/psm/state_query.go
@@ -10,9 +10,9 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-// StateTableSpec is the subset of TableSpec which does not relate to the
+// QueryTableSpec is the subset of TableSpec which does not relate to the
 // specific event and state types of the state machine.
-type StateTableSpec struct {
+type QueryTableSpec struct {
 	StateTable      string
 	StateDataColumn string
 
@@ -37,7 +37,7 @@ type QuerySpec[
 	ListEventsREQ pquery.ListRequest,
 	ListEventsRES pquery.ListResponse,
 ] struct {
-	StateTableSpec
+	QueryTableSpec
 
 	ListRequestFilter       func(ListREQ) (map[string]interface{}, error)
 	ListEventsRequestFilter func(ListEventsREQ) (map[string]interface{}, error)

--- a/testproto/gen/testpb/bar_psm.pb.go
+++ b/testproto/gen/testpb/bar_psm.pb.go
@@ -68,29 +68,35 @@ type BarPSMTableSpec = psm.PSMTableSpec[
 ]
 
 var DefaultBarPSMTableSpec = BarPSMTableSpec{
-	StateTable: "bar",
-	EventTable: "bar_event",
+	State: psm.TableSpec[*BarState]{
+		TableName:  "bar",
+		DataColumn: "state",
+		StoreExtraColumns: func(state *BarState) (map[string]interface{}, error) {
+			return map[string]interface{}{}, nil
+		},
+		PKFieldPaths: []string{
+			"bar_id",
+		},
+	},
+	Event: psm.TableSpec[*BarEvent]{
+		TableName:  "bar_event",
+		DataColumn: "data",
+		StoreExtraColumns: func(event *BarEvent) (map[string]interface{}, error) {
+			metadata := event.Metadata
+			return map[string]interface{}{
+				"id":        metadata.EventId,
+				"timestamp": metadata.Timestamp,
+				"bar_id":    event.BarId,
+			}, nil
+		},
+		PKFieldPaths: []string{
+			"metadata.event_id",
+		},
+	},
 	PrimaryKey: func(event *BarEvent) (map[string]interface{}, error) {
 		return map[string]interface{}{
 			"id": event.BarId,
 		}, nil
-	},
-	StateColumns: func(state *BarState) (map[string]interface{}, error) {
-		return map[string]interface{}{}, nil
-	},
-	EventColumns: func(event *BarEvent) (map[string]interface{}, error) {
-		metadata := event.Metadata
-		return map[string]interface{}{
-			"id":        metadata.EventId,
-			"timestamp": metadata.Timestamp,
-			"bar_id":    event.BarId,
-		}, nil
-	},
-	EventPrimaryKeyFieldPaths: []string{
-		"metadata.event_id",
-	},
-	StatePrimaryKeyFieldPaths: []string{
-		"bar_id",
 	},
 }
 

--- a/testproto/gen/testpb/bar_psm.pb.go
+++ b/testproto/gen/testpb/bar_psm.pb.go
@@ -60,7 +60,7 @@ func NewBarPSM(config *psm.StateMachineConfig[
 	](config)
 }
 
-type BarPSMTableSpec = psm.TableSpec[
+type BarPSMTableSpec = psm.PSMTableSpec[
 	*BarState,
 	BarStatus,
 	*BarEvent,
@@ -258,7 +258,7 @@ type BarPSMQuerySpec = psm.QuerySpec[
 	proto.Message,
 ]
 
-func DefaultBarPSMQuerySpec(tableSpec psm.StateTableSpec) BarPSMQuerySpec {
+func DefaultBarPSMQuerySpec(tableSpec psm.QueryTableSpec) BarPSMQuerySpec {
 	return psm.QuerySpec[
 		*GetBarRequest,
 		*GetBarResponse,
@@ -267,7 +267,7 @@ func DefaultBarPSMQuerySpec(tableSpec psm.StateTableSpec) BarPSMQuerySpec {
 		proto.Message,
 		proto.Message,
 	]{
-		StateTableSpec: tableSpec,
+		QueryTableSpec: tableSpec,
 		ListRequestFilter: func(req *ListBarsRequest) (map[string]interface{}, error) {
 			filter := map[string]interface{}{}
 			if req.TenantId != nil {

--- a/testproto/gen/testpb/foo_psm.pb.go
+++ b/testproto/gen/testpb/foo_psm.pb.go
@@ -68,33 +68,39 @@ type FooPSMTableSpec = psm.PSMTableSpec[
 ]
 
 var DefaultFooPSMTableSpec = FooPSMTableSpec{
-	StateTable: "foo",
-	EventTable: "foo_event",
+	State: psm.TableSpec[*FooState]{
+		TableName:  "foo",
+		DataColumn: "state",
+		StoreExtraColumns: func(state *FooState) (map[string]interface{}, error) {
+			return map[string]interface{}{
+				"tenant_id": state.TenantId,
+			}, nil
+		},
+		PKFieldPaths: []string{
+			"foo_id",
+		},
+	},
+	Event: psm.TableSpec[*FooEvent]{
+		TableName:  "foo_event",
+		DataColumn: "data",
+		StoreExtraColumns: func(event *FooEvent) (map[string]interface{}, error) {
+			metadata := event.Metadata
+			return map[string]interface{}{
+				"id":        metadata.EventId,
+				"timestamp": metadata.Timestamp,
+				"actor":     metadata.Actor,
+				"foo_id":    event.FooId,
+				"tenant_id": event.TenantId,
+			}, nil
+		},
+		PKFieldPaths: []string{
+			"metadata.event_id",
+		},
+	},
 	PrimaryKey: func(event *FooEvent) (map[string]interface{}, error) {
 		return map[string]interface{}{
 			"id": event.FooId,
 		}, nil
-	},
-	StateColumns: func(state *FooState) (map[string]interface{}, error) {
-		return map[string]interface{}{
-			"tenant_id": state.TenantId,
-		}, nil
-	},
-	EventColumns: func(event *FooEvent) (map[string]interface{}, error) {
-		metadata := event.Metadata
-		return map[string]interface{}{
-			"id":        metadata.EventId,
-			"timestamp": metadata.Timestamp,
-			"actor":     metadata.Actor,
-			"foo_id":    event.FooId,
-			"tenant_id": event.TenantId,
-		}, nil
-	},
-	EventPrimaryKeyFieldPaths: []string{
-		"metadata.event_id",
-	},
-	StatePrimaryKeyFieldPaths: []string{
-		"foo_id",
 	},
 }
 

--- a/testproto/gen/testpb/foo_psm.pb.go
+++ b/testproto/gen/testpb/foo_psm.pb.go
@@ -60,7 +60,7 @@ func NewFooPSM(config *psm.StateMachineConfig[
 	](config)
 }
 
-type FooPSMTableSpec = psm.TableSpec[
+type FooPSMTableSpec = psm.PSMTableSpec[
 	*FooState,
 	FooStatus,
 	*FooEvent,
@@ -276,7 +276,7 @@ type FooPSMQuerySpec = psm.QuerySpec[
 	*ListFooEventsResponse,
 ]
 
-func DefaultFooPSMQuerySpec(tableSpec psm.StateTableSpec) FooPSMQuerySpec {
+func DefaultFooPSMQuerySpec(tableSpec psm.QueryTableSpec) FooPSMQuerySpec {
 	return psm.QuerySpec[
 		*GetFooRequest,
 		*GetFooResponse,
@@ -285,7 +285,7 @@ func DefaultFooPSMQuerySpec(tableSpec psm.StateTableSpec) FooPSMQuerySpec {
 		*ListFooEventsRequest,
 		*ListFooEventsResponse,
 	]{
-		StateTableSpec: tableSpec,
+		QueryTableSpec: tableSpec,
 		ListRequestFilter: func(req *ListFoosRequest) (map[string]interface{}, error) {
 			filter := map[string]interface{}{}
 			if req.TenantId != nil {


### PR DESCRIPTION
- Primary Key Fields in TableSpec
- erg...
- List Filter at Request Object
- Bool Filter
- fix collapsing and organize tests
- Nested Field Sort Fix
- start honoring the page size in the request
- give an error if the requested page size exceeds the maximum allowed size
- External Prototest
- Validate PSM Query before trying PSM fallback
- More friendly errors for issues
- add optional description field to foo
- update old tests
- add test showing state marshals in and out like expected
- emit default values
- use same marshal for event and state json
- add failing test
- and use the new way to make the test pass
- more complex sortable field in foo
- build dynamic sorts
- dynamic sort tests
- print query helper to delete later
- fixup tests and add second list of multisort
- drop has check
- add note about get vs has
- more notes
- drop print command now that we're done debugging
- map in use of the tenant id so it's not just null
- add test for listing by tenant id and not by tenant id
- don't add in an empty where
- Protections and wrappers for PSM Event Keys
- Auto-map state keys from event
- services shouldn't be knowing about storing as arrays
- Chain derived actor
- List Filter and List Events Filter are completely independent
- Remove DB from default PSM
- Easier to read aliases
- Unexpose internal fields
- linting
- doesn't need a longer name
- regen
- split helpers off
- wip
- move event creation to helper constructors
- return a proper error
- Event Columns Wrapper
- create a failing test
- convert camel case to snake case for finding the field
- rearrange the tests so we're focussed on features not which set it goes to
- rename example to integration
- consolidate sorting test setup
- DB Sugar
- consistent field names
- Update gitignore for protoc-gen-go-psm
- Allow versions to be set and make a quicker builder script for plugin.
- Improve error message
- make setup data return ids for follow on edits
- tidy up requests
- organize tests cause there's getting to be too many
- add a desc sorting test
- add inversion for more types
- spelling fixes
- make a more complex shape for testing
- create a failing test
- wip
- move test up a level to catch at build
- update proto based on new test
- drop prints etc
- make tests pass
- Error for no metadata, and log default sorts for recursion issue
- return ids from helper to use for edits later
- add space for default filters
- add space for dynamic filters
- add failing test for default filters
- add test for dynamic filter
- skip these for now
- Rename the two table-spec structs'
- Refactor Configs
