### PR TITLE
Idempotent Events

### DIFF
--- a/cmd/protoc-gen-go-psm/state_code.go
+++ b/cmd/protoc-gen-go-psm/state_code.go
@@ -293,6 +293,11 @@ func (ss PSMEntity) addDefaultTableSpec(g *protogen.GeneratedFile) error {
 	g.P("    PKFieldPaths: []string{")
 	g.P("      \"", ss.eventFields.metadataField.Desc.Name(), ".", ss.eventFields.metadataFields.id.Desc.Name(), "\",")
 	g.P("    },")
+	g.P("    PK: func(event *", ss.eventMessage.GoIdent, ") (map[string]interface{}, error) {")
+	g.P("      return map[string]interface{}{")
+	g.P("        \"id\": event.", ss.eventFields.metadataField.GoName, ".", ss.eventFields.metadataFields.id.GoName, ",")
+	g.P("      }, nil")
+	g.P("    },")
 	g.P("  },")
 
 	g.P("  PrimaryKey: func(event *", ss.eventMessage.GoIdent, ") (map[string]interface{}, error) {")

--- a/integration/statemachine_test.go
+++ b/integration/statemachine_test.go
@@ -256,4 +256,29 @@ func TestFooStateMachine(t *testing.T) {
 			t.Fatalf("expected derived event to have actor ID %s, got %s", actorID, derivedEvent.Metadata.Actor.ActorId)
 		}
 	})
+
+	t.Run("Idempotency - event 1", func(t *testing.T) {
+		// idempotency test
+		// event 1 should be idempotent
+		_, err = sm.Transition(ctx, event1)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
+		req := &testpb.ListFooEventsRequest{
+			FooId: fooID,
+		}
+		res := &testpb.ListFooEventsResponse{}
+
+		err = queryer.ListEvents(ctx, db, req, res)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
+		t.Log(protojson.Format(res))
+		if len(res.Events) != 2 {
+			t.Fatalf("expected 2 events for foo 1, got %d", len(res.Events))
+		}
+
+	})
 }

--- a/psm/eventer.go
+++ b/psm/eventer.go
@@ -120,7 +120,7 @@ func (ee Eventer[S, ST, E, IE]) Run(
 		return fmt.Errorf("validating event %s: %w", outerEvent.ProtoReflect().Descriptor().FullName(), err)
 	}
 
-	eventExists, err := tx.CheckEventIdempotency(ctx, outerEvent)
+	eventExists, err := tx.CheckEventExists(ctx, outerEvent)
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func (ee Eventer[S, ST, E, IE]) Run(
 		}
 
 		for _, event := range chained {
-			eventExists, err := tx.CheckEventIdempotency(ctx, event)
+			eventExists, err := tx.CheckEventExists(ctx, event)
 			if err != nil {
 				return err
 			}

--- a/psm/transaction.go
+++ b/psm/transaction.go
@@ -3,47 +3,141 @@ package psm
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 
+	sq "github.com/elgris/sqrl"
+	"github.com/pentops/log.go/log"
 	"github.com/pentops/outbox.pg.go/outbox"
+	"github.com/pentops/protostate/dbconvert"
 	"github.com/pentops/sqrlx.go/sqrlx"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
 type Transaction[State proto.Message, WrappedEvent proto.Message] interface {
 	StoreEvent(context.Context, State, WrappedEvent) error
 	Outbox(context.Context, outbox.OutboxMessage) error
-	CheckEventIdempotency(context.Context, WrappedEvent) (exists bool, err error)
+	CheckEventExists(context.Context, WrappedEvent) (exists bool, err error)
 }
 
-type SqrlxTransaction[State proto.Message, WrappedEvent proto.Message] struct {
-	sqrlx.Transaction
-	storeCallback       func(context.Context, sqrlx.Transaction, State, WrappedEvent) error
-	idempotencyCallback func(context.Context, sqrlx.Transaction, WrappedEvent) (exists bool, err error)
+type SqrlxTransaction[
+	S IState[ST], // Outer State Entity
+	ST IStatusEnum, // Status Enum in State Entity
+	E IEvent[IE], // Event Wrapper, with IDs and Metadata
+	IE IInnerEvent, // Inner Event, the typed event
+] struct {
+	tx   sqrlx.Transaction
+	spec PSMTableSpec[S, ST, E, IE]
 }
 
-func NewSqrlxTransaction[State proto.Message, WrappedEvent proto.Message](
+func NewSqrlxTransaction[
+	S IState[ST], // Outer State Entity
+	ST IStatusEnum, // Status Enum in State Entity
+	E IEvent[IE], // Event Wrapper, with IDs and Metadata
+	IE IInnerEvent, // Inner Event, the typed event
+](
 	tx sqrlx.Transaction,
-	storeCallback func(context.Context, sqrlx.Transaction, State, WrappedEvent) error,
-	idempotencyCallback func(context.Context, sqrlx.Transaction, WrappedEvent) (exists bool, err error),
-) *SqrlxTransaction[State, WrappedEvent] {
-	return &SqrlxTransaction[State, WrappedEvent]{
-		Transaction:         tx,
-		storeCallback:       storeCallback,
-		idempotencyCallback: idempotencyCallback,
+	spec PSMTableSpec[S, ST, E, IE],
+) *SqrlxTransaction[S, ST, E, IE] {
+	return &SqrlxTransaction[S, ST, E, IE]{
+		tx:   tx,
+		spec: spec,
 	}
 }
 
-func (st *SqrlxTransaction[State, WrappedEvent]) StoreEvent(ctx context.Context, state State, event WrappedEvent) error {
-	return st.storeCallback(ctx, st.Transaction, state, event)
+func (st *SqrlxTransaction[S, ST, E, IE]) StoreEvent(ctx context.Context, state S, event E) error {
+	var err error
+
+	stateSpec := st.spec
+
+	stateSetMap, err := stateSpec.State.storeDBMap(state)
+	if err != nil {
+		return fmt.Errorf("state fields: %w", err)
+	}
+
+	primaryKey, err := stateSpec.PrimaryKey(event)
+	if err != nil {
+		return fmt.Errorf("primary key: %w", err)
+	}
+
+	stateKeyMap, err := dbconvert.FieldsToDBValues(primaryKey)
+	if err != nil {
+		return fmt.Errorf("failed to map state primary key to DB values: %w", err)
+	}
+
+	_, err = st.tx.Insert(ctx, sqrlx.
+		Upsert(stateSpec.State.TableName).
+		KeyMap(stateKeyMap).
+		SetMap(stateSetMap))
+
+	if err != nil {
+		log.WithFields(ctx, map[string]interface{}{
+			"stateKeyMap": stateKeyMap,
+			"stateSetMap": stateSetMap,
+			"error":       err.Error(),
+		}).Error("failed to upsert state")
+		return fmt.Errorf("upsert state: %w", err)
+	}
+
+	eventSetMap, err := stateSpec.Event.storeDBMap(event)
+	if err != nil {
+		return fmt.Errorf("event fields: %w", err)
+	}
+
+	_, err = st.tx.Insert(ctx, sq.
+		Insert(stateSpec.Event.TableName).
+		SetMap(eventSetMap))
+	if err != nil {
+		return fmt.Errorf("insert event: %w", err)
+	}
+
+	return nil
+
 }
 
-func (st *SqrlxTransaction[State, WrappedEvent]) Outbox(ctx context.Context, msg outbox.OutboxMessage) error {
-	return outbox.Send(ctx, st.Transaction, msg)
+func (st *SqrlxTransaction[S, ST, E, IE]) Outbox(ctx context.Context, msg outbox.OutboxMessage) error {
+	return outbox.Send(ctx, st.tx, msg)
 }
 
-func (st *SqrlxTransaction[State, WrappedEvent]) CheckEventIdempotency(ctx context.Context, event WrappedEvent) (exists bool, err error) {
-	return st.idempotencyCallback(ctx, st.Transaction, event)
+func (st *SqrlxTransaction[S, ST, E, IE]) CheckEventExists(ctx context.Context, event E) (exists bool, err error) {
+	primaryKey, err := st.spec.Event.PK(event)
+	if err != nil {
+		return false, fmt.Errorf("primary key: %w", err)
+	}
+	pkMap, err := dbconvert.FieldsToDBValues(primaryKey)
+	if err != nil {
+		return false, fmt.Errorf("failed to map event primary key to DB values: %w", err)
+	}
+
+	selectQuery := sq.
+		Select(st.spec.Event.DataColumn).
+		From(st.spec.Event.TableName).
+		Where(sq.Eq(pkMap))
+
+	var data []byte
+	err = st.tx.SelectRow(ctx, selectQuery).Scan(&data)
+	if errors.Is(sql.ErrNoRows, err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("selecting event: %w", err)
+	}
+
+	existing := (*new(E)).ProtoReflect().New()
+
+	if err := protojson.Unmarshal(data, existing.Interface()); err != nil {
+		return false, fmt.Errorf("unmarshalling event: %w", err)
+	}
+
+	if !proto.Equal(existing.Interface(), event) {
+		return false, ErrDuplicateEventID
+	}
+
+	return true, nil
 }
+
+var ErrDuplicateEventID = errors.New("duplicate event ID")
 
 var TxOptions = &sqrlx.TxOptions{
 	Isolation: sql.LevelReadCommitted,

--- a/psm/transaction.go
+++ b/psm/transaction.go
@@ -12,31 +12,37 @@ import (
 type Transaction[State proto.Message, WrappedEvent proto.Message] interface {
 	StoreEvent(context.Context, State, WrappedEvent) error
 	Outbox(context.Context, outbox.OutboxMessage) error
+	CheckEventIdempotency(context.Context, WrappedEvent) (exists bool, err error)
 }
 
 type SqrlxTransaction[State proto.Message, WrappedEvent proto.Message] struct {
 	sqrlx.Transaction
-	callback func(context.Context, sqrlx.Transaction, State, WrappedEvent) error
-}
-
-func (st *SqrlxTransaction[State, WrappedEvent]) StoreEvent(ctx context.Context, state State, event WrappedEvent) error {
-
-	return st.callback(ctx, st.Transaction, state, event)
-}
-
-func (st *SqrlxTransaction[State, WrappedEvent]) Outbox(ctx context.Context, msg outbox.OutboxMessage) error {
-
-	return outbox.Send(ctx, st.Transaction, msg)
+	storeCallback       func(context.Context, sqrlx.Transaction, State, WrappedEvent) error
+	idempotencyCallback func(context.Context, sqrlx.Transaction, WrappedEvent) (exists bool, err error)
 }
 
 func NewSqrlxTransaction[State proto.Message, WrappedEvent proto.Message](
 	tx sqrlx.Transaction,
-	callback func(context.Context, sqrlx.Transaction, State, WrappedEvent) error,
+	storeCallback func(context.Context, sqrlx.Transaction, State, WrappedEvent) error,
+	idempotencyCallback func(context.Context, sqrlx.Transaction, WrappedEvent) (exists bool, err error),
 ) *SqrlxTransaction[State, WrappedEvent] {
 	return &SqrlxTransaction[State, WrappedEvent]{
-		Transaction: tx,
-		callback:    callback,
+		Transaction:         tx,
+		storeCallback:       storeCallback,
+		idempotencyCallback: idempotencyCallback,
 	}
+}
+
+func (st *SqrlxTransaction[State, WrappedEvent]) StoreEvent(ctx context.Context, state State, event WrappedEvent) error {
+	return st.storeCallback(ctx, st.Transaction, state, event)
+}
+
+func (st *SqrlxTransaction[State, WrappedEvent]) Outbox(ctx context.Context, msg outbox.OutboxMessage) error {
+	return outbox.Send(ctx, st.Transaction, msg)
+}
+
+func (st *SqrlxTransaction[State, WrappedEvent]) CheckEventIdempotency(ctx context.Context, event WrappedEvent) (exists bool, err error) {
+	return st.idempotencyCallback(ctx, st.Transaction, event)
 }
 
 var TxOptions = &sqrlx.TxOptions{

--- a/testproto/gen/testpb/bar_psm.pb.go
+++ b/testproto/gen/testpb/bar_psm.pb.go
@@ -92,6 +92,11 @@ var DefaultBarPSMTableSpec = BarPSMTableSpec{
 		PKFieldPaths: []string{
 			"metadata.event_id",
 		},
+		PK: func(event *BarEvent) (map[string]interface{}, error) {
+			return map[string]interface{}{
+				"id": event.Metadata.EventId,
+			}, nil
+		},
 	},
 	PrimaryKey: func(event *BarEvent) (map[string]interface{}, error) {
 		return map[string]interface{}{

--- a/testproto/gen/testpb/foo_psm.pb.go
+++ b/testproto/gen/testpb/foo_psm.pb.go
@@ -96,6 +96,11 @@ var DefaultFooPSMTableSpec = FooPSMTableSpec{
 		PKFieldPaths: []string{
 			"metadata.event_id",
 		},
+		PK: func(event *FooEvent) (map[string]interface{}, error) {
+			return map[string]interface{}{
+				"id": event.Metadata.EventId,
+			}, nil
+		},
 	},
 	PrimaryKey: func(event *FooEvent) (map[string]interface{}, error) {
 		return map[string]interface{}{


### PR DESCRIPTION
Still needs work or at least consideration: The check here de-duplicates, but does not provide idempotency.

The caller to Transition receives the state entity after the transition, and chained transitions, has been applied.
If the input event is duplicated, the state returned to the caller is the current state of the entity.
If the event is *immediately* replayed, this will be fine, but if any other event arrives between the first and second play of the first message, the returned state will be different between the calls.

Option A:
- The transition func should proably always return the state after the *first* transition only, ignoring the subsequent chained events, so that the caller gets the state after the event it passes in. 
- We could store the current state after each event, this is already being considered for other purposes (list events being able to show the state could be useful)
- Then we can return the stored state for the initial event and call it a day.

Simpler options:
- Leave it, it's probably fine
- Throw an error if a further event has occurred, so 'out of order' but to a limit
