### PR TITLE
feat: allow empty min or max in range filter

### DIFF
--- a/integration/filter_test.go
+++ b/integration/filter_test.go
@@ -121,7 +121,7 @@ func TestFilteringWithAuthScope(t *testing.T) {
 		tenantID: tenantID1,
 	}
 
-	ss.StepC("List Page 1", func(ctx context.Context, t flowtest.Asserter) {
+	ss.StepC("List Page", func(ctx context.Context, t flowtest.Asserter) {
 		ctx = tkn.WithToken(ctx)
 
 		req := &testpb.ListFoosRequest{
@@ -220,6 +220,116 @@ func TestDynamicFiltering(t *testing.T) {
 									Type: &psml_pb.Field_Range{
 										Range: &psml_pb.Range{
 											Min: "12",
+											Max: "15",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			res := &testpb.ListFoosResponse{}
+
+			err = queryer.List(ctx, db, req, res)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			if len(res.Foos) != int(4) {
+				t.Fatalf("expected %d states, got %d", 4, len(res.Foos))
+			}
+
+			for ii, state := range res.Foos {
+				t.Logf("%d: %s", ii, state.Field)
+			}
+
+			for ii, state := range res.Foos {
+				if state.Characteristics.Weight != int64(15-ii) {
+					t.Fatalf("expected weight %d, got %d", 15-ii, state.Characteristics.Weight)
+				}
+			}
+
+			pageResp := res.Page
+
+			if pageResp.GetNextToken() != "" {
+				t.Fatalf("NextToken should be empty")
+			}
+			if pageResp.NextToken != nil {
+				t.Fatalf("Should be the final page")
+			}
+		})
+	})
+
+	t.Run("Min Range Filter", func(t *testing.T) {
+		ss.StepC("List Page", func(ctx context.Context, t flowtest.Asserter) {
+			req := &testpb.ListFoosRequest{
+				Page: &psml_pb.PageRequest{
+					PageSize: proto.Int64(5),
+				},
+				Query: &psml_pb.QueryRequest{
+					Filters: []*psml_pb.Filter{
+						{
+							Type: &psml_pb.Filter_Field{
+								Field: &psml_pb.Field{
+									Name: "characteristics.weight",
+									Type: &psml_pb.Field_Range{
+										Range: &psml_pb.Range{
+											Min: "12",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			res := &testpb.ListFoosResponse{}
+
+			err = queryer.List(ctx, db, req, res)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			if len(res.Foos) != int(4) {
+				t.Fatalf("expected %d states, got %d", 4, len(res.Foos))
+			}
+
+			for ii, state := range res.Foos {
+				t.Logf("%d: %s", ii, state.Field)
+			}
+
+			for ii, state := range res.Foos {
+				if state.Characteristics.Weight != int64(15-ii) {
+					t.Fatalf("expected weight %d, got %d", 15-ii, state.Characteristics.Weight)
+				}
+			}
+
+			pageResp := res.Page
+
+			if pageResp.GetNextToken() != "" {
+				t.Fatalf("NextToken should be empty")
+			}
+			if pageResp.NextToken != nil {
+				t.Fatalf("Should be the final page")
+			}
+		})
+	})
+
+	t.Run("Max Range Filter", func(t *testing.T) {
+		ss.StepC("List Page", func(ctx context.Context, t flowtest.Asserter) {
+			req := &testpb.ListFoosRequest{
+				Page: &psml_pb.PageRequest{
+					PageSize: proto.Int64(5),
+				},
+				Query: &psml_pb.QueryRequest{
+					Filters: []*psml_pb.Filter{
+						{
+							Type: &psml_pb.Filter_Field{
+								Field: &psml_pb.Field{
+									Name: "characteristics.weight",
+									Type: &psml_pb.Field_Range{
+										Range: &psml_pb.Range{
 											Max: "15",
 										},
 									},

--- a/integration/filter_test.go
+++ b/integration/filter_test.go
@@ -153,7 +153,7 @@ func TestFilteringWithAuthScope(t *testing.T) {
 			t.Fatal(err.Error())
 		}
 
-		if len(res.Foos) != int(4) {
+		if len(res.Foos) != 4 {
 			t.Fatalf("expected %d states, got %d", 4, len(res.Foos))
 		}
 
@@ -236,7 +236,7 @@ func TestDynamicFiltering(t *testing.T) {
 				t.Fatal(err.Error())
 			}
 
-			if len(res.Foos) != int(4) {
+			if len(res.Foos) != 4 {
 				t.Fatalf("expected %d states, got %d", 4, len(res.Foos))
 			}
 
@@ -291,27 +291,18 @@ func TestDynamicFiltering(t *testing.T) {
 				t.Fatal(err.Error())
 			}
 
-			if len(res.Foos) != int(4) {
-				t.Fatalf("expected %d states, got %d", 4, len(res.Foos))
+			if len(res.Foos) != 5 {
+				t.Fatalf("expected %d states, got %d", 5, len(res.Foos))
 			}
 
 			for ii, state := range res.Foos {
 				t.Logf("%d: %s", ii, state.Field)
 			}
 
-			for ii, state := range res.Foos {
-				if state.Characteristics.Weight != int64(15-ii) {
-					t.Fatalf("expected weight %d, got %d", 15-ii, state.Characteristics.Weight)
+			for _, state := range res.Foos {
+				if state.Characteristics.Weight < int64(12) {
+					t.Fatalf("expected weights greater than or equal to %d, got %d", 12, state.Characteristics.Weight)
 				}
-			}
-
-			pageResp := res.Page
-
-			if pageResp.GetNextToken() != "" {
-				t.Fatalf("NextToken should be empty")
-			}
-			if pageResp.NextToken != nil {
-				t.Fatalf("Should be the final page")
 			}
 		})
 	})
@@ -346,27 +337,18 @@ func TestDynamicFiltering(t *testing.T) {
 				t.Fatal(err.Error())
 			}
 
-			if len(res.Foos) != int(4) {
-				t.Fatalf("expected %d states, got %d", 4, len(res.Foos))
+			if len(res.Foos) != 5 {
+				t.Fatalf("expected %d states, got %d", 5, len(res.Foos))
 			}
 
 			for ii, state := range res.Foos {
 				t.Logf("%d: %s", ii, state.Field)
 			}
 
-			for ii, state := range res.Foos {
-				if state.Characteristics.Weight != int64(15-ii) {
-					t.Fatalf("expected weight %d, got %d", 15-ii, state.Characteristics.Weight)
+			for _, state := range res.Foos {
+				if state.Characteristics.Weight > int64(15) {
+					t.Fatalf("expected weight less than or equal to %d, got %d", 15, state.Characteristics.Weight)
 				}
-			}
-
-			pageResp := res.Page
-
-			if pageResp.GetNextToken() != "" {
-				t.Fatalf("NextToken should be empty")
-			}
-			if pageResp.NextToken != nil {
-				t.Fatalf("Should be the final page")
 			}
 		})
 	})
@@ -428,7 +410,7 @@ func TestDynamicFiltering(t *testing.T) {
 				t.Logf("%d: %s", ii, state.Field)
 			}
 
-			if len(res.Foos) != int(10) {
+			if len(res.Foos) != 10 {
 				t.Fatalf("expected %d states, got %d", 10, len(res.Foos))
 			}
 
@@ -512,7 +494,7 @@ func TestDynamicFiltering(t *testing.T) {
 				t.Logf("%d: %s", ii, state.Field)
 			}
 
-			if len(res.Foos) != int(2) {
+			if len(res.Foos) != 2 {
 				t.Fatalf("expected %d states, got %d", 2, len(res.Foos))
 			}
 
@@ -591,7 +573,7 @@ func TestDynamicFiltering(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if len(res.Foos) != int(5) {
+			if len(res.Foos) != 5 {
 				t.Fatalf("expected %d states, got %d", 5, len(res.Foos))
 			}
 
@@ -633,7 +615,7 @@ func TestDynamicFiltering(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if len(res.Foos) != int(5) {
+			if len(res.Foos) != 5 {
 				t.Fatalf("expected %d states, got %d", 5, len(res.Foos))
 			}
 

--- a/pquery/lister.go
+++ b/pquery/lister.go
@@ -1319,10 +1319,10 @@ func (ll *Lister[REQ, RES]) buildDynamicFilter(tableAlias string, filters []*psm
 					exprStr := fmt.Sprintf("jsonb_path_query_array(%s.%s, '%s ?? (@ >= $min && @ <= $max)', jsonb_build_object('min', ?::text, 'max', ?::text)) <> '[]'::jsonb", tableAlias, ll.dataColumn, field.jsonbPath())
 					out = append(out, sq.And{sq.Expr(exprStr, min, max)})
 				case min != "":
-					exprStr := fmt.Sprintf("jsonb_path_query_array(%s.%s, '%s ?? @ >= $min', jsonb_build_object('min', ?::text)) <> '[]'::jsonb", tableAlias, ll.dataColumn, field.jsonbPath())
+					exprStr := fmt.Sprintf("jsonb_path_query_array(%s.%s, '%s ?? (@ >= $min)', jsonb_build_object('min', ?::text)) <> '[]'::jsonb", tableAlias, ll.dataColumn, field.jsonbPath())
 					out = append(out, sq.And{sq.Expr(exprStr, min)})
 				case max != "":
-					exprStr := fmt.Sprintf("jsonb_path_query_array(%s.%s, '%s ?? @ <= $max', jsonb_build_object('max', ?::text)) <> '[]'::jsonb", tableAlias, ll.dataColumn, field.jsonbPath())
+					exprStr := fmt.Sprintf("jsonb_path_query_array(%s.%s, '%s ?? (@ <= $max)', jsonb_build_object('max', ?::text)) <> '[]'::jsonb", tableAlias, ll.dataColumn, field.jsonbPath())
 					out = append(out, sq.And{sq.Expr(exprStr, max)})
 				}
 			}

--- a/pquery/lister.go
+++ b/pquery/lister.go
@@ -1294,14 +1294,24 @@ func (ll *Lister[REQ, RES]) buildDynamicFilter(tableAlias string, filters []*psm
 
 				out = append(out, sq.And{sq.Expr(fmt.Sprintf("jsonb_path_query_array(%s.%s, '%s') @> ?", tableAlias, ll.dataColumn, field.jsonbPath()), pg.JSONB(val))})
 			case *psml_pb.Field_Range:
-				min, err := validateFilterableField(field.field, filters[i].GetField().GetRange().GetMin())
-				if err != nil {
-					return nil, fmt.Errorf("dynamic filter: range min validation: %w", err)
+				var min, max interface{}
+				min = ""
+				max = ""
+				rawMin := filters[i].GetField().GetRange().GetMin()
+				rawMax := filters[i].GetField().GetRange().GetMax()
+
+				if rawMin != "" {
+					min, err = validateFilterableField(field.field, rawMin)
+					if err != nil {
+						return nil, fmt.Errorf("dynamic filter: range min validation: %w", err)
+					}
 				}
 
-				max, err := validateFilterableField(field.field, filters[i].GetField().GetRange().GetMax())
-				if err != nil {
-					return nil, fmt.Errorf("dynamic filter: range max validation: %w", err)
+				if rawMax != "" {
+					max, err = validateFilterableField(field.field, rawMax)
+					if err != nil {
+						return nil, fmt.Errorf("dynamic filter: range max validation: %w", err)
+					}
 				}
 
 				switch {


### PR DESCRIPTION
Currently, not passing a min or max value is resulting in a timestamp parsing issue in some cases. I see the switch was built to handle an empty value, but it's not reaching that due to the parsing error.