### PR TITLE
State Version Ordering (2)

### DIFF
--- a/integration/statemachine.go
+++ b/integration/statemachine.go
@@ -86,7 +86,9 @@ func NewFooStateMachine(db *sqrlx.Wrapper, actorID string) (*testpb.FooPSMDB, er
 			}
 
 			return nil
-		})).
+		}))
+
+	sm.From().
 		Hook(testpb.FooPSMHook(func(
 			ctx context.Context,
 			tx sqrlx.Transaction,

--- a/integration/statemachine_test.go
+++ b/integration/statemachine_test.go
@@ -229,10 +229,6 @@ func TestFooStateMachine(t *testing.T) {
 			t.Fatal(err.Error())
 		}
 
-		if !proto.Equal(res.State, statesOut[foo2ID]) {
-			t.Fatalf("expected %v, got %v", statesOut[foo2ID], res.State)
-		}
-
 		if res.State.Status != testpb.FooStatus_DELETED {
 			t.Fatalf("expected state DELETED, got %s - Did the chain run?", res.State.Status.ShortString())
 		}


### PR DESCRIPTION
Hooks run on the state prior to the transition (was after)
The main entry should return the state after the first transition (was the last)