### PR TITLE
Multi-Type Walk with Branches

### DIFF
--- a/pquery/lister_test.go
+++ b/pquery/lister_test.go
@@ -132,7 +132,6 @@ func TestFindFieldSpec(t *testing.T) {
 		name string
 	}{
 		{name: "foo"},
-		//{name: "profile.type"},
 		{name: "profile.weight.size"},
 	}
 

--- a/pquery/lister_test.go
+++ b/pquery/lister_test.go
@@ -118,13 +118,13 @@ func TestFindFieldSpec(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if spec.field == nil {
+			if spec.field.field == nil {
 				t.Fatal("expected field")
 			}
 
 			parts := strings.Split(tc.name, ".")
 			name := parts[len(parts)-1]
-			assert.Equal(t, string(spec.field.Name()), name)
+			assert.Equal(t, string(spec.field.field.Name()), name)
 		})
 	}
 
@@ -132,7 +132,7 @@ func TestFindFieldSpec(t *testing.T) {
 		name string
 	}{
 		{name: "foo"},
-		{name: "profile.type"},
+		//{name: "profile.type"},
 		{name: "profile.weight.size"},
 	}
 
@@ -346,7 +346,7 @@ func TestBuildListReflection(t *testing.T) {
 
 				fieldPath := make([]string, len(field.fieldPath))
 				for i, field := range field.fieldPath {
-					fieldPath[i] = string(field.Name())
+					fieldPath[i] = string(field.field.Name())
 				}
 				assert.Equal(t, []string{"bar", "id"}, fieldPath)
 			}
@@ -396,7 +396,7 @@ func TestBuildListReflection(t *testing.T) {
 
 				fieldPath := make([]string, len(field.fieldPath))
 				for i, field := range field.fieldPath {
-					fieldPath[i] = string(field.Name())
+					fieldPath[i] = string(field.field.Name())
 				}
 				assert.Equal(t, []string{"bar", "timestamp"}, fieldPath)
 			}

--- a/pquery/search.go
+++ b/pquery/search.go
@@ -5,61 +5,150 @@ import (
 
 	sq "github.com/elgris/sqrl"
 	"github.com/pentops/protostate/gen/list/v1/psml_pb"
-	"github.com/pentops/protostate/gen/state/v1/psm_pb"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
 
-func validateSearchesAnnotations(ids map[string]struct{}, fields protoreflect.FieldDescriptors) error {
-	if ids == nil {
-		ids = make(map[string]struct{})
+func validateSearchesAnnotations(msg protoreflect.FieldDescriptors) error {
+	fields := make([]protoreflect.FieldDescriptor, msg.Len())
+	for i := 0; i < msg.Len(); i++ {
+		fields[i] = msg.Get(i)
+	}
+	_, err := validateSearchesAnnotationsInner(fields)
+	if err != nil {
+		return fmt.Errorf("search validation: %w", err)
+	}
+	return nil
+}
+
+func validateSearchesAnnotationsInner(fields []protoreflect.FieldDescriptor) (map[string]protoreflect.Name, error) {
+	// search annotations have a 'field_identifier' which specifies the database column name to use for the text-search-vector.
+	// This function validates that the field_identifier is unique for the given field-set
+	// In cases where the field is a message, it will recurse into the message to validate the field identifiers
+
+	// When the same message is used in multiple places, any field of that
+	// message or a child message will, by definition, have the same field
+	// identifier, and is therefore invalid.
+
+	// Search annotation cannot be used in repeated or map fields
+	// Recursion is already invalid.
+
+	// Oneof fields, however, can have the same field identifier on different
+	// branches.
+
+	ids := make(map[string]protoreflect.Name)
+	oneofs := map[string][]protoreflect.FieldDescriptor{}
+
+	for _, field := range fields {
+
+		if oneof := field.ContainingOneof(); oneof != nil {
+			name := string(oneof.Name())
+			oneofs[name] = append(oneofs[name], field)
+			continue
+		}
+
+		err := validateSearchAnnotationsField(ids, field)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	for i := 0; i < fields.Len(); i++ {
-		field := fields.Get(i)
+	for _, oneofFields := range oneofs {
 
-		switch field.Kind() {
-		case protoreflect.StringKind:
-			fieldOpts, ok := proto.GetExtension(field.Options().(*descriptorpb.FieldOptions), psml_pb.E_Field).(*psml_pb.FieldConstraint)
-			if !ok {
-				continue
-			}
+		// oneof fields can have the same field identifier on different branches but must be unique:
+		//  - within the branch, as before
+		//  - with existing parent keys
+		//  - with other oneofs
 
-			switch fieldOpts.GetString_().GetWellKnown().(type) {
-			case *psml_pb.StringRules_OpenText:
-				searchOpts := fieldOpts.GetString_().GetOpenText().GetSearching()
-				if searchOpts == nil || !searchOpts.Searchable {
-					continue
-				}
+		combinedBranchIDs := make(map[string]protoreflect.Name)
 
-				if searchOpts.GetFieldIdentifier() == "" {
-					return fmt.Errorf("field '%s' is missing a field identifier", field.FullName())
-				}
+		for _, field := range oneofFields {
 
-				if _, ok := ids[searchOpts.GetFieldIdentifier()]; ok {
-					return fmt.Errorf("field identifier '%s' is not unique", searchOpts.GetFieldIdentifier())
-				}
-
-				ids[searchOpts.GetFieldIdentifier()] = struct{}{}
-			}
-
-			continue
-		case protoreflect.MessageKind:
-			// Skip event type fields, they are composed of parts from the state
-			fieldOpts := proto.GetExtension(field.Options().(*descriptorpb.FieldOptions), psm_pb.E_EventField).(*psm_pb.EventField)
-			if fieldOpts != nil && fieldOpts.EventType {
-				continue
-			}
-
-			err := validateSearchesAnnotations(ids, field.Message().Fields())
+			// collect a new set of IDs for this branch as if it is the root of
+			// the message.
+			branchIDs := make(map[string]protoreflect.Name)
+			err := validateSearchAnnotationsField(branchIDs, field)
 			if err != nil {
-				return fmt.Errorf("message search validation: %w", err)
+				return nil, err
 			}
+
+			// Compare the branch IDs to the root IDs, if a branch conflicts
+			// with the root that is an error.
+			for searchKey, usedIn := range branchIDs {
+				if existing, ok := ids[searchKey]; ok {
+					return nil, fmt.Errorf("field identifier '%s' is used at %s and %s within the same oneof branch", searchKey, existing, usedIn)
+				}
+
+				// the latest wins here, this makes a worse error message but
+				// doesn't actually effect the outcome.
+				combinedBranchIDs[searchKey] = usedIn
+			}
+
+		}
+
+		// The IDs inside each branch are unique, and unique with the parent keys.
+
+		// We still need to ensure that the IDs are unique with other oneofs.
+		for searchKey, usedIn := range combinedBranchIDs {
+			ids[searchKey] = usedIn
+		}
+
+	}
+
+	return ids, nil
+}
+
+func validateSearchAnnotationsField(ids map[string]protoreflect.Name, field protoreflect.FieldDescriptor) error {
+
+	switch field.Kind() {
+	case protoreflect.StringKind:
+		fieldOpts, ok := proto.GetExtension(field.Options().(*descriptorpb.FieldOptions), psml_pb.E_Field).(*psml_pb.FieldConstraint)
+		if !ok {
+			return nil
+		}
+
+		switch fieldOpts.GetString_().GetWellKnown().(type) {
+		case *psml_pb.StringRules_OpenText:
+			searchOpts := fieldOpts.GetString_().GetOpenText().GetSearching()
+			if searchOpts == nil || !searchOpts.Searchable {
+				return nil
+			}
+
+			if searchOpts.GetFieldIdentifier() == "" {
+				return fmt.Errorf("field '%s' is missing a field identifier", field.FullName())
+			}
+
+			if existing, ok := ids[searchOpts.GetFieldIdentifier()]; ok {
+				return fmt.Errorf("field identifier '%s' is already used at %s", searchOpts.GetFieldIdentifier(), existing)
+			}
+
+			ids[searchOpts.GetFieldIdentifier()] = field.Name()
+		}
+
+		return nil
+	case protoreflect.MessageKind:
+		msg := field.Message().Fields()
+		fields := make([]protoreflect.FieldDescriptor, msg.Len())
+		for i := 0; i < msg.Len(); i++ {
+			fields[i] = msg.Get(i)
+		}
+
+		searchIdentifiers, err := validateSearchesAnnotationsInner(fields)
+		if err != nil {
+			return fmt.Errorf("message search validation: %w", err)
+		}
+		for searchKey, usedIn := range searchIdentifiers {
+			if existing, ok := ids[searchKey]; ok {
+				return fmt.Errorf("field identifier '%s' is already used at %s", searchKey, existing)
+			}
+
+			ids[searchKey] = protoreflect.Name(fmt.Sprintf("%s.%s", field.Name(), usedIn))
 		}
 	}
 
 	return nil
+
 }
 
 func validateQueryRequestSearches(message protoreflect.MessageDescriptor, searches []*psml_pb.Search) error {
@@ -76,14 +165,14 @@ func validateQueryRequestSearches(message protoreflect.MessageDescriptor, search
 		}
 
 		// validate the fields are annotated correctly for the request query
-		searchOpts, ok := proto.GetExtension(spec.field.Options().(*descriptorpb.FieldOptions), psml_pb.E_Field).(*psml_pb.FieldConstraint)
+		searchOpts, ok := proto.GetExtension(spec.field.field.Options().(*descriptorpb.FieldOptions), psml_pb.E_Field).(*psml_pb.FieldConstraint)
 		if !ok {
 			return fmt.Errorf("requested search field '%s' does not have any searchable constraints defined", search.Field)
 		}
 
 		searchable := false
 		if searchOpts != nil {
-			switch spec.field.Kind() {
+			switch spec.field.field.Kind() {
 			case protoreflect.StringKind:
 				switch searchOpts.GetString_().WellKnown.(type) {
 				case *psml_pb.StringRules_OpenText:

--- a/pquery/search_test.go
+++ b/pquery/search_test.go
@@ -1,6 +1,7 @@
 package pquery
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pentops/flowtest/prototest"
@@ -70,12 +71,95 @@ func TestValidateSearchAnnotations(t *testing.T) {
 				field_identifier: "bar_optioned_field"
 			}];
 		}
+
 	`})
 
 		fooDesc := descFiles.MessageByName(t, "test.Foo")
 
-		err := validateSearchesAnnotations(nil, fooDesc.Fields())
+		err := validateSearchesAnnotations(fooDesc.Fields())
 		assert.NoError(t, err)
+	})
+
+	t.Run("multi path duplicates", func(t *testing.T) {
+		descFiles := prototest.DescriptorsFromSource(t, map[string]string{
+			"test.proto": `
+		syntax = "proto3";
+
+		import "psm/list/v1/annotations.proto";
+
+		package test;
+
+		message Msg {
+			string unoptioned_field = 1;
+			string optioned_field = 2 [(psm.list.v1.field).string.open_text.searching = {
+				searchable: true,
+				field_identifier: "optioned_field"
+			}];
+		}
+
+		message Foo {
+			oneof type {
+				Type1 type1 = 1;
+				Type2 type2 = 2;
+			}
+		}
+
+		message Bar {
+			Type1 type1 = 1;
+			Type2 type2 = 2;
+		}
+
+		message Baz {
+			oneof set1 {
+				Type1 s1type1 = 1;
+				Type2 s1type2 = 2;
+			}
+
+			oneof set2 {
+				Type3 type3 = 3;
+				Type4 type4 = 4;
+			}
+
+		}
+
+		message Type1 {
+			Msg msg = 1;
+		}
+		message Type2 {
+			Msg msg = 1;
+		}
+		message Type3 {
+			Msg msg = 1;
+		}
+		message Type4 {
+			Msg msg = 1;
+		}
+	`})
+
+		// Both Type1 and Type2 import the same Msg messaage, which means they
+		// have the same field identifier.
+
+		// Bar is not mutually exclusive, so is not OK
+
+		// This will be a common pattern for event messages.
+
+		// The two instances of Msg within Foo are mutually exclusive, so is OK
+		fooDesc := descFiles.MessageByName(t, "test.Foo")
+		err := validateSearchesAnnotations(fooDesc.Fields())
+		assert.NoError(t, err)
+
+		// The two instances of Msg within Bar are NOT mutually exclusive, this
+		// is not OK.
+		barDesc := descFiles.MessageByName(t, "test.Bar")
+		err = validateSearchesAnnotations(barDesc.Fields())
+		assert.Error(t, err)
+
+		// Each oneof in Baz is OK by itself, but Type1 and Type3 can be set
+		// together, and so the search key can be duplicated.
+		bazDesc := descFiles.MessageByName(t, "test.Baz")
+		err = validateSearchesAnnotations(bazDesc.Fields())
+		fmt.Println(err)
+		assert.Error(t, err)
 	})
 
 	t.Run("duplicate field identifier", func(t *testing.T) {
@@ -107,7 +191,7 @@ func TestValidateSearchAnnotations(t *testing.T) {
 
 		fooDesc := descFiles.MessageByName(t, "test.Foo")
 
-		err := validateSearchesAnnotations(nil, fooDesc.Fields())
+		err := validateSearchesAnnotations(fooDesc.Fields())
 		assert.Error(t, err)
 	})
 
@@ -131,7 +215,7 @@ func TestValidateSearchAnnotations(t *testing.T) {
 
 		fooDesc := descFiles.MessageByName(t, "test.Foo")
 
-		err := validateSearchesAnnotations(nil, fooDesc.Fields())
+		err := validateSearchesAnnotations(fooDesc.Fields())
 		assert.Error(t, err)
 	})
 }

--- a/pquery/sort.go
+++ b/pquery/sort.go
@@ -11,8 +11,8 @@ import (
 )
 
 type sortSpec struct {
-	field     protoreflect.FieldDescriptor
-	fieldPath []protoreflect.FieldDescriptor
+	lastNode  pathNode
+	fieldPath []pathNode
 	desc      bool
 }
 
@@ -20,13 +20,16 @@ func (ss sortSpec) jsonbPath() string {
 	out := strings.Builder{}
 	last := len(ss.fieldPath) - 1
 	for idx, part := range ss.fieldPath {
+		if part.oneof != nil {
+			panic("Oneof node on sortSpec jsonbPath")
+		}
 		// last part gets a double >
 		if idx == last {
 			out.WriteString("->>")
 		} else {
 			out.WriteString("->")
 		}
-		out.WriteString(fmt.Sprintf("'%s'", part.JSONName()))
+		out.WriteString(fmt.Sprintf("'%s'", part.field.JSONName()))
 	}
 
 	return out.String()
@@ -36,7 +39,7 @@ func (ss sortSpec) fieldName() string {
 	out := strings.Builder{}
 	last := len(ss.fieldPath) - 1
 	for idx, part := range ss.fieldPath {
-		out.WriteString(part.JSONName())
+		out.WriteString(part.field.JSONName())
 		if idx != last {
 			out.WriteString(".")
 		}
@@ -52,11 +55,11 @@ func buildTieBreakerFields(req protoreflect.MessageDescriptor, arrayField protor
 		for _, tieBreaker := range listRequestAnnotation.SortTiebreaker {
 			spec, err := findFieldSpec(arrayField, tieBreaker)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("field %s in annotated sort tiebreaker for %s: %w", tieBreaker, req.FullName(), err)
 			}
 
 			tieBreakerFields = append(tieBreakerFields, sortSpec{
-				field:     spec.field,
+				lastNode:  spec.field,
 				fieldPath: spec.fieldPath,
 				desc:      false,
 			})
@@ -73,11 +76,11 @@ func buildTieBreakerFields(req protoreflect.MessageDescriptor, arrayField protor
 	for _, tieBreaker := range fallback {
 		spec, err := findFieldSpec(arrayField, tieBreaker)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("find field spec: %w", err)
 		}
 
 		tieBreakerFields = append(tieBreakerFields, sortSpec{
-			field:     spec.field,
+			lastNode:  spec.field,
 			fieldPath: spec.fieldPath,
 			desc:      false,
 		})
@@ -151,16 +154,24 @@ func buildDefaultSorts(messageFields protoreflect.FieldDescriptors) []sortSpec {
 				}
 			}
 			if isDefaultSort {
+				node := pathNode{
+					field: field,
+					name:  field.Name(),
+				}
 				defaultSortFields = append(defaultSortFields, sortSpec{
-					field:     field,
-					fieldPath: []protoreflect.FieldDescriptor{field},
+					lastNode:  node,
+					fieldPath: []pathNode{node},
 					desc:      true,
 				})
 			}
 		} else if field.Kind() == protoreflect.MessageKind {
 			subSort := buildDefaultSorts(field.Message().Fields())
 			for idx, subSortField := range subSort {
-				subSortField.fieldPath = append([]protoreflect.FieldDescriptor{field}, subSortField.fieldPath...)
+				node := pathNode{
+					field: field,
+					name:  field.Name(),
+				}
+				subSortField.fieldPath = append([]pathNode{node}, subSortField.fieldPath...)
 				subSort[idx] = subSortField
 			}
 
@@ -181,7 +192,7 @@ func (ll *Lister[REQ, RES]) buildDynamicSortSpec(sorts []*psml_pb.Sort) ([]sortS
 		}
 
 		results = append(results, sortSpec{
-			field:     spec.field,
+			lastNode:  spec.field,
 			fieldPath: spec.fieldPath,
 			desc:      sort.Descending,
 		})
@@ -320,14 +331,14 @@ func validateQueryRequestSorts(message protoreflect.MessageDescriptor, sorts []*
 		}
 
 		// validate the fields are annotated correctly for the request query
-		sortOpts, ok := proto.GetExtension(spec.field.Options().(*descriptorpb.FieldOptions), psml_pb.E_Field).(*psml_pb.FieldConstraint)
+		sortOpts, ok := proto.GetExtension(spec.field.field.Options().(*descriptorpb.FieldOptions), psml_pb.E_Field).(*psml_pb.FieldConstraint)
 		if !ok {
 			return fmt.Errorf("requested sort field '%s' does not have any sortable constraints defined", sort.Field)
 		}
 
 		sortable := false
 		if sortOpts != nil {
-			switch spec.field.Kind() {
+			switch spec.field.field.Kind() {
 			case protoreflect.DoubleKind:
 				sortable = sortOpts.GetDouble().GetSorting().Sortable
 			case protoreflect.Fixed32Kind:
@@ -353,7 +364,7 @@ func validateQueryRequestSorts(message protoreflect.MessageDescriptor, sorts []*
 			case protoreflect.Uint64Kind:
 				sortable = sortOpts.GetUint64().GetSorting().Sortable
 			case protoreflect.MessageKind:
-				if spec.field.Message().FullName() == "google.protobuf.Timestamp" {
+				if spec.field.field.Message().FullName() == "google.protobuf.Timestamp" {
 					sortable = sortOpts.GetTimestamp().GetSorting().Sortable
 				}
 			}


### PR DESCRIPTION
Simple one: Unifies the two types of walk used in validate, capturing the oneof next to the field space.
Harder one: Walks the OneOf branches separately when validating search key uniqueness, comments should explain.