### PR TITLE
EventSpec Interface

### DIFF
--- a/cmd/protoc-gen-go-psm/main.go
+++ b/cmd/protoc-gen-go-psm/main.go
@@ -29,6 +29,7 @@ var (
 	smHookFunc              = smImportPath.Ident("PSMHookFunc")
 	smGeneralHookFunc       = smImportPath.Ident("GeneralStateHook")
 	smCombinedFunc          = smImportPath.Ident("PSMCombinedFunc")
+	smEventSpec             = smImportPath.Ident("EventSpec")
 
 	psmProtoImportPath     = protogen.GoImportPath("github.com/pentops/protostate/gen/state/v1/psm_pb")
 	psmEventMetadataStruct = psmProtoImportPath.Ident("EventMetadata")

--- a/integration/event.go
+++ b/integration/event.go
@@ -4,58 +4,51 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/pentops/protostate/gen/state/v1/psm_pb"
 	"github.com/pentops/protostate/testproto/gen/testpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"k8s.io/utils/ptr"
 )
 
-func newFooCreatedEvent(fooID, tenantID string, mod func(c *testpb.FooEventType_Created)) *testpb.FooEvent {
-	e := newFooEvent(fooID, tenantID, func(e *testpb.FooEvent) {
-		weight := int64(10)
-		e.Event.Type = &testpb.FooEventType_Created_{
-			Created: &testpb.FooEventType_Created{
-				Name:        "foo",
-				Field:       fmt.Sprintf("weight: %d", weight),
-				Description: ptr.To("creation event for foo: " + fooID),
-				Weight:      &weight,
-			},
-		}
+func newFooCreatedEvent(fooID, tenantID string, mod func(c *testpb.FooEventType_Created)) *testpb.FooPSMEventSpec {
+	weight := int64(10)
+	created := &testpb.FooEventType_Created{
+		Name:        "foo",
+		Field:       fmt.Sprintf("weight: %d", weight),
+		Description: ptr.To("creation event for foo: " + fooID),
+		Weight:      &weight,
+	}
+	e := newFooEvent(fooID, tenantID, func(e *testpb.FooPSMEventSpec) {
+		e.Event = created
 	})
 
 	if mod != nil {
-		mod(e.Event.GetCreated())
+		mod(created)
 	}
 
 	return e
 }
 
-func newFooUpdatedEvent(fooID, tenantID string, mod func(u *testpb.FooEventType_Updated)) *testpb.FooEvent {
-	e := newFooEvent(fooID, tenantID, func(e *testpb.FooEvent) {
-		weight := int64(20)
-		e.Event.Type = &testpb.FooEventType_Updated_{
-			Updated: &testpb.FooEventType_Updated{
-				Name:        "foo",
-				Field:       fmt.Sprintf("weight: %d", weight),
-				Description: ptr.To("update event for foo: " + fooID),
-				Weight:      &weight,
-			},
-		}
+func newFooUpdatedEvent(fooID, tenantID string, mod func(u *testpb.FooEventType_Updated)) *testpb.FooPSMEventSpec {
+	weight := int64(20)
+	updated := &testpb.FooEventType_Updated{
+		Name:        "foo",
+		Field:       fmt.Sprintf("weight: %d", weight),
+		Description: ptr.To("update event for foo: " + fooID),
+		Weight:      &weight,
+	}
+	e := newFooEvent(fooID, tenantID, func(e *testpb.FooPSMEventSpec) {
+		e.Event = updated
 	})
 
 	if mod != nil {
-		mod(e.Event.GetUpdated())
+		mod(updated)
 	}
 
 	return e
 }
 
-func newFooEvent(fooID, tenantID string, mod func(e *testpb.FooEvent)) *testpb.FooEvent {
-	e := &testpb.FooEvent{
-		Metadata: &psm_pb.EventMetadata{
-			EventId:   uuid.NewString(),
-			Timestamp: timestamppb.Now(),
-		},
+func newFooEvent(fooID, tenantID string, mod func(e *testpb.FooPSMEventSpec)) *testpb.FooPSMEventSpec {
+	e := &testpb.FooPSMEventSpec{
+		EventID: uuid.NewString(),
 		Keys: &testpb.FooKeys{
 			FooId:    fooID,
 			TenantId: &tenantID,
@@ -66,29 +59,25 @@ func newFooEvent(fooID, tenantID string, mod func(e *testpb.FooEvent)) *testpb.F
 	return e
 }
 
-func newBarCreatedEvent(barID string, mod func(c *testpb.BarEventType_Created)) *testpb.BarEvent {
-	e := newBarEvent(barID, func(e *testpb.BarEvent) {
-		e.Event.Type = &testpb.BarEventType_Created_{
-			Created: &testpb.BarEventType_Created{
-				Name:  "bar",
-				Field: "event",
-			},
-		}
+func newBarCreatedEvent(barID string, mod func(c *testpb.BarEventType_Created)) *testpb.BarPSMEventSpec {
+	created := &testpb.BarEventType_Created{
+		Name:  "bar",
+		Field: "event",
+	}
+	e := newBarEvent(barID, func(e *testpb.BarPSMEventSpec) {
+		e.Event = created
 	})
 
 	if mod != nil {
-		mod(e.Event.GetCreated())
+		mod(created)
 	}
 
 	return e
 }
 
-func newBarEvent(barID string, mod func(e *testpb.BarEvent)) *testpb.BarEvent {
-	e := &testpb.BarEvent{
-		Metadata: &psm_pb.EventMetadata{
-			EventId:   uuid.NewString(),
-			Timestamp: timestamppb.Now(),
-		},
+func newBarEvent(barID string, mod func(e *testpb.BarPSMEventSpec)) *testpb.BarPSMEventSpec {
+	e := &testpb.BarPSMEventSpec{
+		EventID: uuid.NewString(),
 		Keys: &testpb.BarKeys{
 			BarId: barID,
 		},

--- a/integration/foo_testmachine.go
+++ b/integration/foo_testmachine.go
@@ -81,7 +81,7 @@ func NewFooTestMachine(t *testing.T, db *sqrlx.Wrapper) *FooTester {
 			event *testpb.FooEventType_Updated,
 		) error {
 			if event.Delete {
-				baton.ChainDerived(&testpb.FooEventType_Deleted{})
+				baton.DeriveEvent(&testpb.FooEventType_Deleted{})
 			}
 			return nil
 		}))

--- a/integration/statemachine.go
+++ b/integration/statemachine.go
@@ -96,7 +96,7 @@ func NewFooStateMachine(db *sqrlx.Wrapper, actorID string) (*testpb.FooPSMDB, er
 			event *testpb.FooEventType_Updated,
 		) error {
 			if event.Delete {
-				baton.ChainDerived(&testpb.FooEventType_Deleted{})
+				baton.DeriveEvent(&testpb.FooEventType_Deleted{})
 			}
 			return nil
 		}))
@@ -126,9 +126,9 @@ func NewBarStateMachine(db *sqrlx.Wrapper) (*testpb.BarPSMDB, error) {
 				"timestamp": event.Metadata.Timestamp,
 			}, nil
 		}).
-		PrimaryKey(func(event *testpb.BarEvent) (map[string]interface{}, error) {
+		PrimaryKey(func(keys *testpb.BarKeys) (map[string]interface{}, error) {
 			return map[string]interface{}{
-				"id": event.Keys.BarId,
+				"id": keys.BarId,
 			}, nil
 		}).NewStateMachine()
 	if err != nil {

--- a/psm/builder.go
+++ b/psm/builder.go
@@ -52,7 +52,7 @@ func (cb *StateMachineConfig[K, S, ST, E, IE]) StoreExtraEventColumns(eventColum
 	return cb
 }
 
-func (cb *StateMachineConfig[K, S, ST, E, IE]) PrimaryKey(primaryKey func(E) (map[string]interface{}, error)) *StateMachineConfig[K, S, ST, E, IE] {
+func (cb *StateMachineConfig[K, S, ST, E, IE]) PrimaryKey(primaryKey func(K) (map[string]interface{}, error)) *StateMachineConfig[K, S, ST, E, IE] {
 	cb.spec.PrimaryKey = primaryKey
 	return cb
 }


### PR DESCRIPTION
Changing the entry point for PSM Transitions to take a Go struct rather than a proto, where we will do more validation of what is being sent in.

- [ ] Map out Actor
- [ ] Derive state machine name in cause
- [ ] Cross Machine Events
- [ ] Take keys *out* of the EventSpec