### PR TITLE
fix: trying to ensure action sets cause

### DIFF
--- a/psm/event.go
+++ b/psm/event.go
@@ -36,7 +36,7 @@ type EventSpec[
 	Timestamp time.Time
 }
 
-func (es EventSpec[K, S, ST, SD, E, IE]) validateAndPrepare() error {
+func (es *EventSpec[K, S, ST, SD, E, IE]) validateAndPrepare() error {
 
 	if !es.Keys.PSMIsSet() {
 		return fmt.Errorf("EventSpec.Keys is required")


### PR DESCRIPTION
I think the receiver needs to a be a pointer to allow the cause to be set. Currently, I'm seeing all causes but commands coming through.